### PR TITLE
Update amprupdate.py

### DIFF
--- a/amprupdate/amprupdate.py
+++ b/amprupdate/amprupdate.py
@@ -152,7 +152,7 @@ def main():
         if routes_to_add:
             commands.append("# adding new and modified routes")
         for dstaddress, interface in routes_to_add:
-            commands.append("/interface ipip add local-address=%s name=ampr-%s remote-address=%s" % (edge_router_ip, interface, interface))
+            commands.append("/interface ipip add !keepalive clamp-tcp-mss=yes local-address=%s name=ampr-%s remote-address=%s" % (edge_router_ip, interface, interface))
             commands.append("/ip route add dst-address=%s gateway=ampr-%s distance=30" % (dstaddress, interface))
             commands.append("/ip neighbor discovery set ampr-%s discover=no" % (interface))
 


### PR DESCRIPTION
RouterOS 6.22 activates keepalive by default with 10 seconds interval, resulting in unnecessary packets being sent to remote endpoints and eventually interface flapping due to missing support for keepalive packets.
The clamp-tcp-mss allows to automatically clamp the TCP MSS, so there no need for a Firewall entry anymore.
